### PR TITLE
Maker: vaults from a wallet

### DIFF
--- a/defi_protocols/Maker.py
+++ b/defi_protocols/Maker.py
@@ -116,3 +116,38 @@ def get_delegated_MKR(wallet: str, block: Union[int, str],
                          web3=web3, decimals=decimals)
 
     return [[ETHTokenAddr.MKR, balance]]
+
+
+# This classes are just a working draft
+# of a possible refactor
+
+class Contract:
+    ADDRESS = 'replace_me_or_watch_me_fail'
+
+    def __init__(self, block):
+        self.block = block
+        self.web3 = get_node(ETHEREUM, block=self.block)
+        self.contract = get_contract(self.ADDRESS, ETHEREUM, web3=self.web3,
+                                     block=self.block)
+
+    def __getattr__(self, a):
+        fun = getattr(self.contract.functions, a)
+        def aux(*args, **kwargs):
+            return fun(*args, **kwargs).call(block_identifier=self.block)
+        return aux
+
+
+class ProxyRegistry(Contract):
+    ADDRESS = '0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4'
+
+
+class CDPManager(Contract):
+    ADDRESS = CDP_MANAGER_ADDRESS
+
+    def vaults(self, wallet_address: str):
+        wallet_address = self.web3.to_checksum_address(wallet_address)
+        # I'm sorry if walruses scare you := := :=
+        _vs = [_next := self.first(wallet_address)]
+        while (_next := self.list(_next)[1]) > 0:
+            _vs.append(_next)
+        return _vs

--- a/tests/test_maker.py
+++ b/tests/test_maker.py
@@ -7,9 +7,10 @@ from defi_protocols.constants import ETHEREUM, DAI_ETH, WETH_ETH, ETHTokenAddr
 TEST_BLOCK = 17070386
 WEB3 = get_node(blockchain=ETHEREUM, block=TEST_BLOCK)
 # TEST_WALLET = '0xf929122994e177079c924631ba13fb280f5cd1f9'
-# TEST_WALLET = '0x849D52316331967b6fF1198e5E32A0eB168D039d'
-TEST_WALLET = '0x4971DD016127F390a3EF6b956Ff944d0E2e1e462'
+TEST_WALLET_1 = '0x4971DD016127F390a3EF6b956Ff944d0E2e1e462'
+TEST_WALLET_2 = '0x849D52316331967b6fF1198e5E32A0eB168D039d'
 VAULT_ID = 27353
+TEST_WALLET_2_PROXY = '0xD758500ddEc05172aaA035911387C8E0e789CF6a'
 
 
 def test_get_vault_data():
@@ -31,7 +32,27 @@ def test_underlying():
     assert x == [[ETHTokenAddr.stETH, 57328.918780519],
                  [DAI_ETH, -22548608.444234513]]
 
+
 def test_get_delegated_MKR():
-    x = Maker.get_delegated_MKR(TEST_WALLET, TEST_BLOCK, WEB3,
+    x = Maker.get_delegated_MKR(TEST_WALLET_1, TEST_BLOCK, WEB3,
                                 decimals=False)
     assert x == [[ETHTokenAddr.MKR, 583805204609736124092]]
+
+
+def test_proxies():
+    pr = Maker.ProxyRegistry(TEST_BLOCK)
+    p = pr.proxies(TEST_WALLET_2)
+    assert p == TEST_WALLET_2_PROXY
+
+
+def test_vault_count():
+    cdp = Maker.CDPManager(TEST_BLOCK)
+    c = cdp.count(TEST_WALLET_2_PROXY)
+    assert c == 2
+
+
+def test_vaults_from_wallet():
+    pr = Maker.ProxyRegistry(TEST_BLOCK)
+    cdp = Maker.CDPManager(pr.block)
+    _vs = cdp.vaults(pr.proxies(TEST_WALLET_2))
+    assert _vs == [27353, 29954]


### PR DESCRIPTION
See the test to learn how to use it.

This PR also shows a possible way for refactoring contracts code, using `__getattr__` magic.